### PR TITLE
Failover when tx not found for associated deployment address

### DIFF
--- a/cli/forge_broadcasts.rs
+++ b/cli/forge_broadcasts.rs
@@ -171,7 +171,29 @@ pub fn get_last_deployments(
                                                             },
                                                         );
                                                     } else {
-                                                        eprintln!("could not find tx for in-memory deployed contract {} at {}", name, address);
+                                                        new_deployments.insert(
+                                                            format!(
+                                                                "{}::{}",
+                                                                deployment_context,
+                                                                name.to_string()
+                                                            ),
+                                                            DeploymentObject {
+                                                                name: name.to_string(),
+                                                                address: address.to_string(),
+                                                                bytecode: bytecode.to_string(),
+                                                                args_data: args_data.to_string(),
+                                                                tx_hash: "".to_string(),
+                                                                args: Some(vec![]),
+                                                                data: "".to_string(),
+                                                                contract_name: contract_name
+                                                                    .map(|s| s.to_string()),
+                                                                artifact_path: artifact_path
+                                                                    .to_string(),
+                                                                deployment_context:
+                                                                    deployment_context.to_string(),
+                                                                chain_id: chain_id.to_string(),
+                                                            },
+                                                        );
                                                     }
                                                 }
                                             } else {


### PR DESCRIPTION
Quick and dirty workaround I made so that it's possible to deploy a contract using CREATE3 factory and be able to have a deployment file when running sync.

It doesn't have all the info but at least there's a deployment. It's not meant to be merged as is but to discuss a solution around it.

Example use case:
```
function deployUsingCreate3(
        string memory deploymentName,
        bytes32 salt,
        string memory artifactName,
        bytes memory constructorArgs,
        uint value
    ) internal returns (address instance) {
        Create3Factory factory = Create3Factory(constants.getAddress(ChainId.All, "create3Factory"));

        if (deployer.has(deploymentName)) {
            return deployer.getAddress(deploymentName);
        } else {
            bytes memory creationCode = vm.getCode(artifactName);
            instance = factory.deploy(salt, abi.encodePacked(creationCode, constructorArgs), value);
            deployer.save(deploymentName, instance, artifactName, constructorArgs, creationCode);
        }
    }
```

once sync is ran, it results in a deployment with some of the fields empty but sufficient for what I need