### PR TITLE
Slash path fix

### DIFF
--- a/cli/forge_broadcasts.rs
+++ b/cli/forge_broadcasts.rs
@@ -10,20 +10,25 @@ use serde_json::{from_str, Value};
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all(deserialize = "camelCase", serialize = "camelCase"))]
 pub struct Transaction {
-    r#type: String, // example: "0x02"
+    r#type: String,
+    // example: "0x02"
     from: String,
-    gas: String,           // example: "0xca531"
-    value: Option<String>, // example:  "0x0"
-    data: String,          // "0x..."
-    nonce: String,         // example: "0xd5"
-                           // "accessList": []
+    gas: String,
+    // example: "0xca531"
+    value: Option<String>,
+    // example:  "0x0"
+    data: String,
+    // "0x..."
+    nonce: String, // example: "0xd5"
+                   // "accessList": []
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all(deserialize = "camelCase", serialize = "camelCase"))]
 pub struct TransactionResult {
     hash: String,
-    transaction_type: String, // CREATE, CREATE2
+    transaction_type: String,
+    // CREATE, CREATE2
     contract_name: Option<String>,
     contract_address: Option<String>,
     arguments: Option<Vec<String>>,
@@ -98,7 +103,17 @@ pub fn get_last_deployments(
                                                 let regex_result = re.captures_iter(value.as_str());
 
                                                 for cap in regex_result {
-                                                    let parts = cap[1].split(", ");
+                                                    println!("cap[1]: {:?}", cap[1].to_string());
+
+                                                    let parts_string = cap[1]
+                                                        .to_string()
+                                                        .replace("\\", "")
+                                                        .replace("\"", "");
+
+                                                    let parts = parts_string.split(", ");                                                    //.map(|s| {
+                                                    //    s.replace("\\", "").replace("\"", "")
+                                                    //})
+                                                    //.collect();
                                                     let collection = parts.collect::<Vec<&str>>();
                                                     let name = collection[0];
                                                     let address = collection[1];
@@ -147,6 +162,20 @@ pub fn get_last_deployments(
 
                                                         // println!("{}:{}", artifact_path, contract_name.unwrap_or("unknown"));
                                                         // println!("{} address: {}, artifact_path: {}, contract_name: {}, deployment_context: {}", name, address, artifact_path, contract_name, deployment_context);
+
+                                                        println!(
+                                                            "name: {} \
+                                                        address: {}, \
+                                                        artifact_path: {}, \
+                                                        contract_name: {}, \
+                                                        deployment_context: {}",
+                                                            name,
+                                                            address,
+                                                            artifact_path,
+                                                            contract_name.unwrap(),
+                                                            deployment_context
+                                                        );
+
                                                         new_deployments.insert(
                                                             format!(
                                                                 "{}::{}",


### PR DESCRIPTION
# Description
For some reason the regex match result would have a whole lot of unnecessary slashes and quotes in it. I've pr
```
cap[1]: "\\\"ArshansCounter\\\", 0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3, 0x608060405234801561001057600080fd5b5060f78061001f6000396000f3fe6080604052348015600f57600080fd5b5060043610603c5760003560e01c80633fb5c1cb1460415780638381f58a146053578063d09de08a14606d575b600080fd5b6051604c3660046083565b600055565b005b605b60005481565b60405190815260200160405180910390f35b6051600080549080607c83609b565b9190505550565b600060208284031215609457600080fd5b5035919050565b60006001820160ba57634e487b7160e01b600052601160045260246000fd5b506001019056fea26469706673582212209a4f596646aef03148ba539a8ea6044f2863de3c2541eb20089448240adad94864736f6c63430008170033, 0x, \\\"Counter.sol:Counter\\\", \\\"10\\\", \\\"10\\\""
name: ArshansCounter address: 0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3, artifact_path: Counter.sol, contract_name: Counter, deployment_context: 10
```
This would result in the deployment folder not being made, and the deployments file not being written to. 

I'm guessing it could be because of discrepancy across systems?

## My system
<img width="392" alt="image" src="https://github.com/wighawag/forge-deploy/assets/10492324/22ace366-392a-4d40-a16e-fc4adeeb2e9c">

## Rust Version
```
(base) ➜  forge-deploy git:(slash-path-fix) ✗ cargo --version
cargo 1.73.0 (9c4383fb5 2023-08-26)
(base) ➜  forge-deploy git:(slash-path-fix) ✗ rustc --version
rustc 1.73.0 (cc66ad468 2023-10-03)
```