### PR TITLE
check existence of directory and file

### DIFF
--- a/cli/forge_broadcasts.rs
+++ b/cli/forge_broadcasts.rs
@@ -49,7 +49,7 @@ pub fn get_last_deployments(
     let mut new_deployments: HashMap<String, DeploymentObject> = HashMap::new();
 
     // return early if directory does not exist
-    if folder_path_buf.is_dir() { return new_deployments; }
+    if !folder_path_buf.is_dir() { return new_deployments; }
 
     for script_dir in fs::read_dir(folder_path_buf).unwrap() {
         match script_dir {
@@ -63,6 +63,8 @@ pub fn get_last_deployments(
                                     // println!("chain: {}", chain_dir.path().display());
                                     let filepath_buf = chain_dir.path().join("run-latest.json");
                                     // let filepath = filepath_buf.to_str().unwrap();
+
+                                    if !filepath_buf.is_file() { break; }
 
                                     let data = fs::read_to_string(filepath_buf)
                                         .expect("Unable to read file");


### PR DESCRIPTION
* Adds missing `!` to ensure the directory does **not** exist introduce by #21
* Checks that the `run-latest.json` file exists in the chain directory
  * I ran into error reading the file when I did a dry run which instead nests everything in the `dry-run` sub-directory